### PR TITLE
catch invalid key when translating direction commands. I.e., if a use…

### DIFF
--- a/command_line_parser/textParser.py
+++ b/command_line_parser/textParser.py
@@ -182,10 +182,22 @@ class TextParser:
 
     def translateDirectionToRoom(self, roomObj, userCommandDict):
         if userCommandDict["direction"]["word"] != "" and userCommandDict["room"]["word"] == "":
-            userCommandDict["room"]["word"] = roomObj.directions[userCommandDict["direction"]["word"]]
-            userCommandDict["room"]["index"] = userCommandDict["direction"]["index"]
-            userCommandDict["direction"]["word"] = ""
-            userCommandDict["direction"]["index"] = ""
+            validDirection = False
+            for key in roomObj.directions:
+                if userCommandDict["direction"]["word"] == key:
+                    validDirection = True
+            if validDirection == True:
+                userCommandDict["room"]["word"] = roomObj.directions[userCommandDict["direction"]["word"]]
+                userCommandDict["room"]["index"] = userCommandDict["direction"]["index"]
+                userCommandDict["direction"]["word"] = ""
+                userCommandDict["direction"]["index"] = ""
+            else:
+                userCommandDict["direction"]["word"] = ""
+                userCommandDict["direction"]["index"] = ""
+                userCommandDict["verb"]["word"] = ""
+                userCommandDict["verb"]["index"] = ""
+                userCommandDict["room"]["word"] = ""
+                userCommandDict["room"]["index"] = ""
 
     '''
     interpretRoom, among other interpret commands can be used in a loop to figure out the user command

--- a/command_line_parser/textParserUnitTest.py
+++ b/command_line_parser/textParserUnitTest.py
@@ -215,5 +215,16 @@ class TestTextParser(unittest.TestCase):
         parsedCommand = textParser.getCommand(command, test_room_obj, test_player_obj)
         assert parsedCommand == {'verb': 'go', 'room': 'guestRoom', 'direction': ''}
 
+    def test_direction_translation_invalid(self):
+        test_room_obj = Room("hallway2.json")
+        test_player_obj = Player("player.json")
+        command = "go north"
+        parsedCommand = textParser.getCommand(command, test_room_obj, test_player_obj)
+        assert parsedCommand == {}
+
+        command = "north"
+        parsedCommand = textParser.getCommand(command, test_room_obj, test_player_obj)
+        assert parsedCommand == {}
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
…r says "go north" and there is no room connected to the north, return an empty dictionary