### PR TITLE
Bleeding effect

### DIFF
--- a/haunted_mansion_game/actions.py
+++ b/haunted_mansion_game/actions.py
@@ -18,6 +18,8 @@ class Actions:
             game_state.display_current_room()
             if game_state.player.status == "poisoned":
                 game_state.poison_effect()
+            if game_state.player.bleeding:
+                game_state.bleeding_effect()
         else:
             if "masterKey" in game_state.player.inventory:
                 print "You unlocked this room using the master key."
@@ -29,6 +31,8 @@ class Actions:
                 game_state.display_current_room()
                 if game_state.player.status == "poisoned":
                     game_state.poison_effect()
+                if game_state.player.bleeding:
+                    game_state.bleeding_effect()
             else:
                 print "This room is locked."
 
@@ -48,7 +52,8 @@ class Actions:
             game_state.display_current_room()
             if game_state.player.status == "poisoned":
                 game_state.poison_effect()
-
+            if game_state.player.bleeding:
+                game_state.bleeding_effect()
 
     @classmethod
     def inventory(cls, game_state, *parsed_command):

--- a/haunted_mansion_game/game_state.py
+++ b/haunted_mansion_game/game_state.py
@@ -65,6 +65,7 @@ class GameState:
 
     # FIXME: Crashes when it tries to print displayName of features without json files
     def display_current_room(self):
+        print "Health: {}%".format(self.player.health)
         current_room = self.get_current_room()
         current_room.display_room_msg()
         print "***ROOM FEATURE***"
@@ -105,16 +106,16 @@ class GameState:
 
     def poison_effect(self):
         # If player takes 12 steps while poisoned, the game ends
-        if self.player.poisonedSteps == 3:
-            print "You start having a coughing fit."
-        elif self.player.poisonedSteps == 6:
+        self.player.poisonedSteps += 1
+        if self.player.poisonedSteps == 6:
+            print "You feel ill and start having a coughing fit."
+        elif self.player.poisonedSteps == 8:
             print "You puked bile on the floor."
-        elif self.player.poisonedSteps == 9:
+        elif self.player.poisonedSteps == 10:
             print "Your mouth starts to foam with blood."
         elif self.player.poisonedSteps == 12:
             print "You collapse on the ground and seized. You died."
             exit()
-        self.player.poisonedSteps += 1
 
     def cure_poison(self):
         if self.player.status == "poisoned":
@@ -122,4 +123,12 @@ class GameState:
             print "You feel much better now."
         else:
             print "You feel no difference."
+
+    def bleeding_effect(self):
+        self.player.health -= 2
+        if self.player.health <= 0:
+            print "You've bleed out too much. You died."
+            exit()
+        elif self.player.health == 16:
+            print "You've lost a lot of blood. You're in critical health."
 

--- a/resources/player/player.json
+++ b/resources/player/player.json
@@ -4,5 +4,7 @@
   "currentRoom" : "livingRoom",
   "inventory" : [],
   "status" : "Alive",
+  "health" : 40,
+  "bleeding" : true,
   "poisonedSteps": 0
 }

--- a/resources/rooms/garden.json
+++ b/resources/rooms/garden.json
@@ -3,7 +3,7 @@
   "connectedTo": ["kitchen", "courtyard"],
   "displayName": "Garden",
   "features": ["gazebo", "shed", "bench"],
-  "objects": ["carBatteryJumper"],
+  "objects": [],
   "visited": false,
   "longMSG": "You are in the garden. \n There are a gazebo and a shed.\n You may go...\n    south to the kitchen through the backdoor, or\n    southwest to the courtyard through the garden gate.\n",
   "shortMSG": "You are in the garden. \n Features: gazebo, shed.\n Areas you may go to:\n    south - backdoor to kitchen - 1st floor\n    southwest - garden gate to courtyard\n",

--- a/resources/rooms/livingRoom.json
+++ b/resources/rooms/livingRoom.json
@@ -21,6 +21,6 @@
                 "south": "courtYard",
                 "west": "diningRoom"
               },
-  "locked" : true,
+  "locked" : false,
   "hidden" : true
 }


### PR DESCRIPTION
Added bleeding effect. Player loses 2% health per room movement and starts with 40%
Remove battery jumper from garden.
Unlocked Living Room (starting room should always be unlocked)